### PR TITLE
Add shortest path between two vertices

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -105,4 +105,24 @@ class GraphAlgorithms:
                     heapq.heappush(priority_queue, (new_distance, neighbor))
         
         return [(vertex, distances[vertex]) for vertex in vertices]
+
+    def shortest_distance_between_two_points(self,graph:Graph,source:Any,dest:Any) -> Union[int,float]:
+        """This function uses the dijstra's algorithm to get the shortest distance between a given source vertex and destination vertex
+
+        Args:
+            graph (Graph): An instance of the graph class from the Prep Module. 
+            source (Any): The starting point
+            dest (Any): The ending point
+
+        Returns:
+            int: Returns the smallest possible distance between Source and Destination 
+        """
+        all_distances = self.dijkstra(graph, source)
+        for vertex, distance in all_distances:
+            if vertex == dest:
+                return distance
+        
+        raise ValueError(f"Provided Destination vertex {dest} does not exist in the graph")
+    
             
+        

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -29,3 +29,18 @@ class TestAlgorithms(unittest.TestCase):
         ])
         shorted_paths = self.algorithms.dijkstra(g,source='a')
         self.assertCountEqual(shorted_paths, [('c', 8), ('b', 4), ('d', 12), ('e', 14), ('a', 0)])
+    
+    def test_shortest_distance_between_two_points(self):
+        g = Graph([
+            ('a', 'b', 4), ('a','c',8),('b','d',8),('b','c',11),('c','e',7),('e','d',2)
+        ])
+        shortest_distance = self.algorithms.shortest_distance_between_two_points(g, 'a', 'e')
+        self.assertEqual(shortest_distance, 14)
+    
+    def test_shortest_distance_between_two_points_missing_vertex(self):
+        g = Graph([
+            ('a', 'b', 4), ('a','c',8),('b','d',8),('b','c',11),('c','e',7),('e','d',2)
+        ])
+        with self.assertRaises(ValueError):
+            self.algorithms.shortest_distance_between_two_points(g,'a','z')
+        


### PR DESCRIPTION
This method finds the shortest distance between the source and the destination vertex. This is currently reusing the dijstra's method already present for the all shortest distances problem so it's not optimized for large graphs. 